### PR TITLE
build(deps): bump actions/checkout to v7 and ghaction-import-gpg to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Create dummy file
         run: |

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     # with those associated to the GPG key
     - name: Import GPG key
       id: import-gpg
-      uses: crazy-max/ghaction-import-gpg@v6
+      uses: crazy-max/ghaction-import-gpg@v7
       with:
         gpg_private_key: ${{ env.GPG_PRIVATE_KEY }}
         passphrase: ${{ env.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v5 to v7 in the CI workflow
- Bump `crazy-max/ghaction-import-gpg` from v6 to v7 in the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)